### PR TITLE
Include sesson token verification in socket.io connection

### DIFF
--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -180,6 +180,14 @@ function sendClientReady(isReconnect, messageType)
   socket.json.send(msg);
 }
 
+function getSessionToken(location)
+{
+  var params = (new URL(location)).searchParams;
+  var sessionToken = params.get("sessionToken") || "missing";
+
+  return sessionToken;
+}
+
 function handshake()
 {
   var loc = document.location;
@@ -189,10 +197,13 @@ function handshake()
   var url = loc.protocol + "//" + loc.hostname + ":" + port + "/";
   //find out in which subfolder we are
   var resource =  exports.baseURL.substring(1)  + "socket.io";
+  //get session token
+  var sessionToken = getSessionToken(loc);
   //connect
   socket = pad.socket = io.connect(url, {
     // Allow deployers to host Etherpad on a non-root path
     'path': exports.baseURL + "socket.io",
+    'query': "sessionToken=" + sessionToken,
     'resource': resource,
     'reconnectionAttempts': 5,
     'reconnection' : true,

--- a/src/static/js/pad_impexp.js
+++ b/src/static/js/pad_impexp.js
@@ -180,6 +180,14 @@ var padimpexp = (function()
     return false;
   }
 
+  function getSessionToken(location)
+  {
+    var params = (new URL(location)).searchParams;
+    var sessionToken = params.get("sessionToken") || "missing";
+
+    return sessionToken;
+  }
+
   /////
   var pad = undefined;
   var self = {
@@ -199,10 +207,13 @@ var padimpexp = (function()
         $('#importsubmitinput').val(html10n.get("pad.impexp.importbutton"));
       })
 
+      var sessionToken = getSessionToken(document.location);
+      var sessionTokenParam = "?sessionToken=" + sessionToken;
+
       // build the export links
-      $("#exporthtmla").attr("href", pad_root_path + "/export/html");
-      $("#exportetherpada").attr("href", pad_root_path + "/export/etherpad");
-      $("#exportplaina").attr("href", pad_root_path + "/export/txt");
+      $("#exporthtmla").attr("href", pad_root_path + "/export/html" + sessionTokenParam);
+      $("#exportetherpada").attr("href", pad_root_path + "/export/etherpad" + sessionTokenParam);
+      $("#exportplaina").attr("href", pad_root_path + "/export/txt" + sessionTokenParam);
 
       // activate action to import in the form
       $("#importform").attr('action', pad_root_url + "/import");
@@ -220,17 +231,17 @@ var padimpexp = (function()
       {
         $("#exportpdfa").remove();
 
-        $("#exportworda").attr("href", pad_root_path + "/export/doc");
-        $("#exportopena").attr("href", pad_root_path + "/export/odt");
+        $("#exportworda").attr("href", pad_root_path + "/export/doc" + sessionTokenParam);
+        $("#exportopena").attr("href", pad_root_path + "/export/odt" + sessionTokenParam);
 
         $("#importexport").css({"height":"142px"});
         $("#importexportline").css({"height":"142px"});
       }
       else
       {
-        $("#exportworda").attr("href", pad_root_path + "/export/doc");
-        $("#exportpdfa").attr("href", pad_root_path + "/export/pdf");
-        $("#exportopena").attr("href", pad_root_path + "/export/odt");
+        $("#exportworda").attr("href", pad_root_path + "/export/doc" + sessionTokenParam);
+        $("#exportpdfa").attr("href", pad_root_path + "/export/pdf" + sessionTokenParam);
+        $("#exportopena").attr("href", pad_root_path + "/export/odt" + sessionTokenParam);
       }
 
       addImportFrames();


### PR DESCRIPTION
Tries to fix https://github.com/bigbluebutton/security/issues/11 and https://github.com/bigbluebutton/security/issues/28

Replace `notes.nginx` for:
```
# https://github.com/ether/etherpad-lite/wiki/How-to-put-Etherpad-Lite-behind-a-reverse-Proxy
location /pad/p/ {
    rewrite /pad/p/(.*) /p/$1 break;
    rewrite ^/pad/p$ /pad/p/ permanent;
    proxy_pass http://localhost:9001/p;
    proxy_pass_header Server;
    proxy_redirect /p /pad/p;
    proxy_set_header Host $host;
    proxy_buffering off;

    auth_request /bigbluebutton/connection/checkAuthorization;
    auth_request_set $auth_status $upstream_status;
}

location /pad {
    rewrite /pad/(.*) /$1 break;
    rewrite ^/pad$ /pad/ permanent;
    proxy_pass http://localhost:9001/;
    proxy_pass_header Server;
    proxy_redirect / /pad/;
    proxy_set_header Host $host;
    proxy_buffering off;
}

location /pad/socket.io/socket.io.js {
    rewrite /pad/socket.io/socket.io.js /socket.io/socket.io.js break;
    proxy_pass http://localhost:9001/;
    proxy_set_header Host $host;
    proxy_buffering off;
}
    
location /pad/socket.io {
    rewrite /pad/socket.io/(.*) /socket.io/$1 break;
    proxy_pass http://localhost:9001/;
    proxy_redirect / /pad/;
    proxy_set_header Host $host;
    proxy_buffering off;
    proxy_set_header X-Real-IP $remote_addr;  # http://wiki.nginx.org/HttpProxyModule
    proxy_set_header X-Forwarded-For $remote_addr; # EP logs to show the actual remote IP
    proxy_set_header X-Forwarded-Proto $scheme; # for EP to set secure cookie flag when https is used
    proxy_set_header Host $host;  # pass the host header
    proxy_http_version 1.1;  # recommended with keepalive connections
    # WebSocket proxying - from http://nginx.org/en/docs/http/websocket.html
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "Upgrade";

    auth_request /bigbluebutton/connection/checkAuthorization;
    auth_request_set $auth_status $upstream_status;
}

location /static {
    rewrite /static/(.*) /static/$1 break;
    proxy_pass http://localhost:9001/;
    proxy_set_header Host $host;
    proxy_buffering off;
}
```