### PR TITLE
Fix cookies configuration

### DIFF
--- a/src/node/hooks/express/specialpages.js
+++ b/src/node/hooks/express/specialpages.js
@@ -60,6 +60,7 @@ exports.expressCreateServer = function (hook_name, args, cb) {
          * Please note that this will not be compatible with applications being
          * served over http and https at the same time.
          */
+        sameSite: "None",
         secure: (req.protocol === 'https'),
       }
       res.cookie('language', settings.padOptions.lang, cookieOptions);

--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -132,6 +132,12 @@ exports.expressConfigure = function (hook_name, args, cb) {
     proxy: true,
     cookie: {
       /*
+       * Firefox started enforcing sameSite, see https://github.com/ether/etherpad-lite/issues/3989
+       * for details.  In response we set it based on if SSL certs are set in Etherpad.  Note that if
+       * You use Nginx or so for reverse proxy this may cause problems.  Use Certificate pinning to remedy.
+       */
+      sameSite: "None",
+      /*
        * The automatic express-session mechanism for determining if the
        * application is being served over ssl is similar to the one used for
        * setting the language cookie, which check if one of these conditions is

--- a/src/static/js/pad_cookie.js
+++ b/src/static/js/pad_cookie.js
@@ -46,7 +46,8 @@ var padcookie = (function()
     var expiresDate = new Date();
     expiresDate.setFullYear(3000);
     var secure = isHttpsScheme() ? ";secure" : "";
-    document.cookie = (cookieName + "=" + safeText + ";expires=" + expiresDate.toGMTString() + secure);
+    var sameSite = ";sameSite=None";
+    document.cookie = (cookieName + "=" + safeText + ";expires=" + expiresDate.toGMTString() + secure + sameSite);
   }
 
   function parseCookie(text)

--- a/src/static/js/pad_utils.js
+++ b/src/static/js/pad_utils.js
@@ -56,13 +56,14 @@ function createCookie(name, value, days, path){ /* Used by IE */
 
   //Check if we accessed the pad over https
   var secure = window.location.protocol == "https:" ? ";secure" : "";
+  var sameSite = ";sameSite=None";
 
   //Check if the browser is IE and if so make sure the full path is set in the cookie
   if((navigator.appName == 'Microsoft Internet Explorer') || ((navigator.appName == 'Netscape') && (new RegExp("Trident/.*rv:([0-9]{1,}[\.0-9]{0,})").exec(navigator.userAgent) != null))){
-    document.cookie = name + "=" + value + expires + "; path=/" + secure; /* Note this bodge fix for IE is temporary until auth is rewritten */
+    document.cookie = name + "=" + value + expires + "; path=/" + secure + sameSite; /* Note this bodge fix for IE is temporary until auth is rewritten */
   }
   else{
-    document.cookie = name + "=" + value + expires + "; path=" + path + secure;
+    document.cookie = name + "=" + value + expires + "; path=" + path + secure + sameSite;
   }
 
 }


### PR DESCRIPTION
Cookies that are intended for third-party or cross-site contexts
must specify SameSite=None and Secure

This must be included at nginx's `/pad/p/` location

```
    proxy_set_header X-Real-IP $remote_addr;  # http://wiki.nginx.org/HttpProxyModule
    proxy_set_header X-Forwarded-For $remote_addr; # EP logs to show the actual remote IP
    proxy_set_header X-Forwarded-Proto $scheme; # for EP to set secure cookie flag when https is used
```