### PR TITLE
Add settings option to force SameSite=None server side

### DIFF
--- a/settings.json.template
+++ b/settings.json.template
@@ -312,6 +312,11 @@
   "trustProxy": true,
 
   /*
+   * When embedding the pads in an iframe set this to true.
+   */
+  "forceSameSiteNone": false,
+
+  /*
    * Privacy: disable IP logging
    */
   "disableIPlogging": false,

--- a/src/node/hooks/express/specialpages.js
+++ b/src/node/hooks/express/specialpages.js
@@ -38,6 +38,16 @@ exports.expressCreateServer = function (hook_name, args, cb) {
     });
   });
 
+  if (settings.forceSameSiteNone) {
+    var sameSite = "None";
+  } else {
+    if (settings.ssl) {
+      var sameSite = "Strict";
+    } else {
+      var sameSite = "Lax";
+    }
+  }
+
   //serve pad.html under /p
   args.app.get('/p/:pad', function(req, res, next)
   {
@@ -60,7 +70,7 @@ exports.expressCreateServer = function (hook_name, args, cb) {
          * Please note that this will not be compatible with applications being
          * served over http and https at the same time.
          */
-        sameSite: "None",
+        sameSite: sameSite,
         secure: (req.protocol === 'https'),
       }
       res.cookie('language', settings.padOptions.lang, cookieOptions);

--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -122,6 +122,16 @@ exports.expressConfigure = function (hook_name, args, cb) {
     exports.secret = settings.sessionKey;
   }
 
+  if (settings.forceSameSiteNone) {
+    var sameSite = "None";
+  } else {
+    if (settings.ssl) {
+      var sameSite = "Strict";
+    } else {
+      var sameSite = "Lax";
+    }
+  }
+
   args.app.sessionStore = exports.sessionStore;
   args.app.use(sessionModule({
     secret: exports.secret,
@@ -136,7 +146,7 @@ exports.expressConfigure = function (hook_name, args, cb) {
        * for details.  In response we set it based on if SSL certs are set in Etherpad.  Note that if
        * You use Nginx or so for reverse proxy this may cause problems.  Use Certificate pinning to remedy.
        */
-      sameSite: "None",
+      sameSite: sameSite,
       /*
        * The automatic express-session mechanism for determining if the
        * application is being served over ssl is similar to the one used for

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -246,6 +246,11 @@ exports.sessionKey = false;
 exports.trustProxy = false;
 
 /*
+ * Force cookie SameSite=None, whether or not force SameSite=None configuration.
+ */
+exports.forceSameSiteNone = false;
+
+/*
  * This setting is used if you need authentication and/or
  * authorization. Note: /admin always requires authentication, and
  * either authorization by a module, or a user with is_admin set


### PR DESCRIPTION
Disabled as default. When embedding the pad in an iframe, set
forceSameSiteNone to true.