### PR TITLE
Fix readOnly pad export

### DIFF
--- a/src/node/db/ReadOnlyManager.js
+++ b/src/node/db/ReadOnlyManager.js
@@ -23,6 +23,15 @@ var db = require("./DB");
 var randomString = require("../utils/randomstring");
 
 /**
+ * checks if the id pattern matches a read-only pad id
+ * @param {String} the pad's id
+ */
+exports.isReadOnlyId = function(id)
+{
+  return id.indexOf("r.") === 0;
+}
+
+/**
  * returns a read only id for a pad
  * @param {String} padId the id of the pad
  */

--- a/src/node/handler/ExportHandler.js
+++ b/src/node/handler/ExportHandler.js
@@ -49,9 +49,9 @@ const tempDirectory = os.tmpdir();
 /**
  * do a requested export
  */
-async function doExport(req, res, padId, type)
+async function doExport(req, res, padId, readOnlyId, type)
 {
-  var fileName = padId;
+  var fileName = readOnlyId ? readOnlyId : padId;
 
   // allow fileName to be overwritten by a hook, the type type is kept static for security reasons
   let hookFileName = await hooks.aCallFirst("exportFileName", padId);
@@ -130,9 +130,9 @@ async function doExport(req, res, padId, type)
   }
 }
 
-exports.doExport = function(req, res, padId, type)
+exports.doExport = function(req, res, padId, readOnlyId, type)
 {
-  doExport(req, res, padId, type).catch(err => {
+  doExport(req, res, padId, readOnlyId, type).catch(err => {
     if (err !== "stop") {
       throw err;
     }

--- a/src/static/css/pad.css
+++ b/src/static/css/pad.css
@@ -22,9 +22,6 @@ textarea {
 iframe {
   position: absolute
 }
-.readonly .acl-write {
-  display: none;
-}
 
 #users {
   background: #f7f7f7;


### PR DESCRIPTION
The export request hook wasn't testing if the pad's id was from a read-only
pad before validating with the pad manager.

This includes an extra step that makes the read-only id verification and also
avoids setting the original pad's id as the file's name.