### PR TITLE
Listen to 127.0.0.1 Only

### DIFF
--- a/settings.json.template
+++ b/settings.json.template
@@ -85,7 +85,7 @@
   /*
    * IP and port which etherpad should bind at
    */
-  "ip": "0.0.0.0",
+  "ip": "127.0.0.1",
   "port": 9001,
 
   /*


### PR DESCRIPTION
This patch makes BigBlueButton's Etherpad listen to 127.0.0.1 only which
is sufficient since Nginx acts as a reverse proxy in front of this
anyway.