### PR TITLE
Fix readOnlyID fetch on pad removal

### DIFF
--- a/src/node/db/Pad.js
+++ b/src/node/db/Pad.js
@@ -476,7 +476,7 @@ Pad.prototype.remove = async function remove() {
   }
 
   // remove the readonly entries
-  let readonlyID = readOnlyManager.getReadOnlyId(padID);
+  let readonlyID = await readOnlyManager.getReadOnlyId(padID);
 
   db.remove("pad2readonly:" + padID);
   db.remove("readonly2pad:" + readonlyID);


### PR DESCRIPTION
We need to wait for the ReadOnlyManager to finish before removing `pad2readonly`
because it's the same key `getReadOnlyId` uses to fetch it.