### PR TITLE
Replace pad's content removal plugin

### DIFF
--- a/settings.json.template
+++ b/settings.json.template
@@ -418,17 +418,11 @@
   /*
   "indentationOnNewLine": false,
   */
-
-  /*
-   * Delete pads plugin configuration.
-   * npm i ep_delete_after_delay_lite
-   */
-
-  "ep_delete_after_delay_lite": {
-    "delay": 86400, // one day, in seconds
-    "loop": true,
-    "loopDelay": 3600, // one hour, in seconds
-    "deleteAtStart": true
+  
+  "ep_pad_ttl": {
+    "ttl": 21600, // 6 hours
+    "timeout": 5,
+    "interval": 3600 // 1 hour
   },
 
   /*


### PR DESCRIPTION
ep_delete_after_delay_lite is being deprecated in favor of ep_pad_ttl