### PR TITLE
Drop cookies expiration to Session

### DIFF
--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -154,7 +154,7 @@ function sendClientReady(isReconnect, messageType)
   if (token == null)
   {
     token = "t." + randomString();
-    createCookie("token", token, 60);
+    createCookie("token", token);
   }
 
   var sessionID = decodeURIComponent(readCookie("sessionID"));

--- a/src/static/js/pad_cookie.js
+++ b/src/static/js/pad_cookie.js
@@ -43,11 +43,9 @@ var padcookie = (function()
 
   function setRawCookie(safeText)
   {
-    var expiresDate = new Date();
-    expiresDate.setFullYear(3000);
     var secure = isHttpsScheme() ? ";secure" : "";
     var sameSite = ";sameSite=None";
-    document.cookie = (cookieName + "=" + safeText + ";expires=" + expiresDate.toGMTString() + secure + sameSite);
+    document.cookie = (cookieName + "=" + safeText + secure + sameSite);
   }
 
   function parseCookie(text)


### PR DESCRIPTION
Following suggestions from https://github.com/bigbluebutton/bigbluebutton/issues/11497#issuecomment-791356293,
both perfs and token client-side cookies expiration was reduced to Session
to avoid some conflicts with sessionstorage's flushes.

